### PR TITLE
Make composer-yaml compatible with packagist installations

### DIFF
--- a/bin/composer-yaml
+++ b/bin/composer-yaml
@@ -1,7 +1,11 @@
 #!/usr/bin/php
 <?php
 
-require __DIR__.'/../vendor/.composer/autoload.php';
+if (file_exists(__DIR__.'/../vendor/autoload.php')) {
+    require __DIR__.'/../vendor/autoload.php';
+} elseif (file_exists(__DIR__.'/../../../autoload.php')) {
+    require __DIR__.'/../../../autoload.php';
+}
 
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputInterface;


### PR DESCRIPTION
When installed using igorw/composer-yaml, the autoloading paths are wrong. I included a cheap fix that checks for a "parallel" `vendor` directory first (assuming the file was just copied to the project `bin` folder) and then for the structure found when installed through composer (`vendor/igorw/composer-yaml`).

It's not much, but now the user can actually install composer-yaml through packagist and use it directly.
