### PR TITLE
Use PHP from environment for more compatibility 

### DIFF
--- a/bin/composer-yaml
+++ b/bin/composer-yaml
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 if (file_exists(__DIR__.'/../vendor/autoload.php')) {


### PR DESCRIPTION
Use php from the environment to be a bit more compatible with various setups
