### PR TITLE
Fixed symfony dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
     "description": "Tool to convert from composer.yml to composer.json.",
     "license": "MIT",
     "require": {
-        "symfony/console": "2.1.*",
-        "symfony/yaml": "2.1.*",
+        "symfony/console": "~2.1",
+        "symfony/yaml": "~2.1",
         "composer/composer": "1.0.*@dev"
     },
     "bin": [

--- a/composer.yml
+++ b/composer.yml
@@ -2,8 +2,8 @@ name: igorw/composer-yaml
 description: Tool to convert from composer.yml to composer.json.
 license: MIT
 require:
-    symfony/console: '2.1.*'
-    symfony/yaml: '2.1.*'
+    symfony/console: '~2.1'
+    symfony/yaml: '~2.1'
     composer/composer: '1.0.*@dev'
 bin:
     - bin/composer-yaml


### PR DESCRIPTION
allow to install higher versions of symfony, to prevent breaking in combination with current composer version
